### PR TITLE
Update api.py

### DIFF
--- a/archiveis/api.py
+++ b/archiveis/api.py
@@ -18,13 +18,13 @@ def capture(
     Returns the URL where the capture is stored.
     """
     # Put together the URL that will save our request
-    domain = "http://archive.is"
+    domain = "http://archive.vn"
     save_url = urljoin(domain, "/submit/")
 
     # Configure the request headers
     headers = {
         'User-Agent': user_agent,
-        "host": "archive.is",
+        "host": "archive.vn",
     }
 
     # Request a unique identifier for our activity

--- a/test.py
+++ b/test.py
@@ -10,7 +10,7 @@ class CaptureTest(unittest.TestCase):
 
     def test_capture(self):
         archive_url_1 = archiveis.capture("http://www.example.com/")
-        self.assertTrue(archive_url_1.startswith("http://archive.is/"))
+        self.assertTrue(archive_url_1.startswith("http://archive.vn/"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Quick fix for "too many redirects" [as mentioned here](https://github.com/pastpages/archiveis/issues/7) archive.is has been relocated to archive.vn. With this change, the library works again.