### PR TITLE
General update of setup and versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
-*egg-info/
+# Compiled python
 *.pyc
+
+# Packaging
 dist/
 build/
+*.egg-info/
+
+# Tests
+.tox/
 .coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,27 @@ sudo: false
 
 language: python
 
-cache: pip
-
-python:
-  - 2.7
-  - 3.5
-  - 3.6
-
 cache:
-  - pip
+  pip: true
+
+matrix:
+  include:
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: "3.7"
+      env: TOXENV=py37
+    - python: "3.8-dev"
+      env: TOXENV=py38
+  allow_failures:
+    - python: "3.8-dev"
+      env: TOXENV=py38
+  # fast_finish: true
 
 install:
   - pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See where it's stored.
 
 ```python
 >>> print archive_url
-http://archive.vn/WxlRK
+http://archive.fo/WxlRK
 ```
 
 If a URL has been recently cached, archive.is may return the URL to that page rather

--- a/archiveis/__init__.py
+++ b/archiveis/__init__.py
@@ -3,7 +3,7 @@
 from .api import capture
 
 
-__version__ = "0.0.5"
+__version__ = "0.0.7"
 __all__ = (
     'capture',
 )

--- a/archiveis/api.py
+++ b/archiveis/api.py
@@ -18,13 +18,13 @@ def capture(
     Returns the URL where the capture is stored.
     """
     # Put together the URL that will save our request
-    domain = "http://archive.vn"
+    domain = "http://archive.fo"
     save_url = urljoin(domain, "/submit/")
 
     # Configure the request headers
     headers = {
         'User-Agent': user_agent,
-        "host": "archive.vn",
+        "host": "archive.fo",
     }
 
     # Request a unique identifier for our activity

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: MIT License',
     ],
     install_requires=[

--- a/test.py
+++ b/test.py
@@ -10,7 +10,7 @@ class CaptureTest(unittest.TestCase):
 
     def test_capture(self):
         archive_url_1 = archiveis.capture("http://www.example.com/")
-        self.assertTrue(archive_url_1.startswith("http://archive.vn/"))
+        self.assertTrue(archive_url_1.startswith("http://archive.fo/"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Among other things (like Python 3.7), the archive.today domain now redirects to archive.fo