### PR TITLE
Split post logic and memento parsing into separate functions

### DIFF
--- a/archiveis/api.py
+++ b/archiveis/api.py
@@ -70,19 +70,7 @@ def do_post(
     return requests.post(save_url, **post_kwargs)
 
 
-def capture(
-    target_url,
-    user_agent="archiveis (https://github.com/pastpages/archiveis)",
-    proxies={},
-):
-    """
-    Archives the provided URL using archive.is
-
-    Returns the URL where the capture is stored.
-    """
-    response = do_post(target_url, user_agent, proxies)
-    response.raise_for_status()
-
+def parse_memento(response):
     # There are a couple ways the header can come back
     if 'Refresh' in response.headers:
         memento = str(response.headers['Refresh']).split(';url=')[1]
@@ -106,6 +94,21 @@ def capture(
     logger.error(response.headers)
     logger.error(response.text)
     raise Exception("No memento returned by archive.is")
+
+
+def capture(
+    target_url,
+    user_agent="archiveis (https://github.com/pastpages/archiveis)",
+    proxies={},
+):
+    """
+    Archives the provided URL using archive.is
+
+    Returns the URL where the capture is stored.
+    """
+    response = do_post(target_url, user_agent, proxies)
+    response.raise_for_status()
+    return parse_memento(response)
 
 
 @click.command()

--- a/archiveis/api.py
+++ b/archiveis/api.py
@@ -7,15 +7,16 @@ from six.moves.urllib.parse import urljoin
 logger = logging.getLogger(__name__)
 
 
-def capture(
+def do_post(
     target_url,
     user_agent="archiveis (https://github.com/pastpages/archiveis)",
-    proxies={}
+    proxies={},
+    anyway=1
 ):
     """
     Archives the provided URL using archive.is
 
-    Returns the URL where the capture is stored.
+    Returns the POST response object
     """
     # Put together the URL that will save our request
     domain = "http://archive.fo"
@@ -51,7 +52,7 @@ def capture(
     # Send the capture request to archive.is with the unique id included
     data = {
         "url": target_url,
-        "anyway": 1,
+        "anyway": anyway,
     }
     if unique_id:
         data.update({"submitid": unique_id})
@@ -66,7 +67,20 @@ def capture(
         post_kwargs['proxies'] = proxies
 
     logger.debug("Requesting {}".format(save_url))
-    response = requests.post(save_url, **post_kwargs)
+    return requests.post(save_url, **post_kwargs)
+
+
+def capture(
+    target_url,
+    user_agent="archiveis (https://github.com/pastpages/archiveis)",
+    proxies={},
+):
+    """
+    Archives the provided URL using archive.is
+
+    Returns the URL where the capture is stored.
+    """
+    response = do_post(target_url, user_agent, proxies)
     response.raise_for_status()
 
     # There are a couple ways the header can come back


### PR DESCRIPTION
And allow specifying the `anyway` flag in case you want to retrieve existing archives instead of always creating a new one.

I have a use case where I want to inspect the most-recently-archived date, but don't care much about the URL. Working directly with the POST response object would be easier for me than downloading the same content over again.